### PR TITLE
New Version and fix for RHEL 8 / Rocky 8 tries to build with included libmaxmindd-devel

### DIFF
--- a/SPECS/libmodsecurity.spec
+++ b/SPECS/libmodsecurity.spec
@@ -100,6 +100,7 @@ applications that use %{name}.
 %changelog
 * Tue Oct 29 2024 Ruben Herold <ruben@insecure.pw> 3.0.13-1
 - Bump to 3.0.13
+- Limit version for libmaxminddb-devel
 
 * Wed Jan 31 2024 Karl Johnson <karljohnson.it@gmail.com> 3.0.12-1
 - Bump to 3.0.12

--- a/SPECS/libmodsecurity.spec
+++ b/SPECS/libmodsecurity.spec
@@ -1,6 +1,6 @@
 
 Name: libmodsecurity
-Version: 3.0.12
+Version: 3.0.13
 Release: 1%{?dist}
 Summary: A library that loads/interprets rules written in the ModSecurity SecRules
 Group: System/Libraries
@@ -98,6 +98,9 @@ applications that use %{name}.
 
 
 %changelog
+* Tue Oct 29 2024 Ruben Herold <ruben@insecure.pw> 3.0.13-1
+- Bump to 3.0.13
+
 * Wed Jan 31 2024 Karl Johnson <karljohnson.it@gmail.com> 3.0.12-1
 - Bump to 3.0.12
 

--- a/SPECS/libmodsecurity.spec
+++ b/SPECS/libmodsecurity.spec
@@ -16,7 +16,7 @@ BuildRequires: flex
 BuildRequires: bison
 BuildRequires: git-core
 BuildRequires: ssdeep-devel
-BuildRequires: libmaxminddb-devel
+BuildRequires: libmaxminddb-devel >= 1.5.2
 BuildRequires: lua-devel
 BuildRequires: doxygen
 BuildRequires: pkgconfig(libxml-2.0)


### PR DESCRIPTION
hi,

I  push the version to the current libmodsecurity.  

I tried to build this on an pure Rocky 8 with the in Rocky 8 included libmaxminddb-devel (1.2.0).  So users are forced to replace it with minium the version in Rocky 9 where the build runs without any problems.